### PR TITLE
 	Added mrkdwn_in field to attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Check out https://api.slack.com/docs/attachments for more details
 	$attachment->setAuthor("Author name", "Optional author link e.g. http://flickr.com/bobby/", "Optional author icon e.g. http://flickr.com/bobby/picture.jpg");
 	$attachment->setTitle("Title", "Optional link e.g. http://www.cloock.be/");
 	$attachment->setImage("http://www.domain.com/picture.jpg");
+	$attachment->setMrkDwnIn("title");
+	$attachment->setMrkDwnIn("text");
 	
 	 // Add fields, last parameter stand for short (smaller field) and is optional
 	$attachment->addField("Title", "Value", true);

--- a/slack.php
+++ b/slack.php
@@ -245,6 +245,7 @@ class SlackAttachment{
 	public $title_link;
 	public $text;
 	public $fields;
+	public $mrkdwn_in;
 	public $image_url;
 	
 	function __construct($fallback){
@@ -275,6 +276,14 @@ class SlackAttachment{
 	}
 	function setAuthorName($author_name) {
 		$this->author_name = $author_name;
+		return $this;
+	}
+	function setMrkDwnIn($mrkdwn_in) {
+		if (!isset($this->mrkdwn_in_fields)){
+			$this->mrkdwn_in_fields = array($mrkdwn_in);
+			return $this;
+		}
+		$this->mrkdwn_in_fields[] = $mrkdwn_in;
 		return $this;
 	}
 	/**
@@ -326,6 +335,8 @@ class SlackAttachment{
 			$data['pretext'] = $this->pretext;
 		if (isset($this->author_name))
 			$data['author_name'] = $this->author_name;
+		if (isset($this->mrkdwn_in_fields))
+			$data['mrkdwn_in'] = $this->mrkdwn_in_fields;
 		if (isset($this->author_link))
 			$data['author_link'] = $this->author_link;
 		if (isset($this->author_icon))


### PR DESCRIPTION
I added the mrkdwn_in field to attachments.
Now it is possible to use basic text formatting in attachments.